### PR TITLE
Resolvers - task query and createTask mutation

### DIFF
--- a/apollo/schemas/resolvers.ts
+++ b/apollo/schemas/resolvers.ts
@@ -1,9 +1,30 @@
 import { Task, User } from '../../src/pages/api/models';
+import { Types } from 'mongoose';
+
+enum TaskStatus {
+  active = 'active',
+  completed = 'completed',
+}
+
+interface Task {
+  id: number;
+  title: string;
+  status: TaskStatus;
+}
 
 const resolvers = {
   Query: {
-    tasks(parent, args, context) {
-      return [];
+    tasks: async (
+      parent, 
+      args: { status?: TaskStatus }, 
+      context
+    ): Promise<Task[]> => {
+      try {
+        const tasks = await Task.find()
+        return args.status ? tasks.filter(task => task.status === args.status) : tasks;
+      } catch (err) {
+        console.error(err);
+      };
     },
     task(parent, args, context) {
       return null;
@@ -19,8 +40,20 @@ const resolvers = {
     }
   },
   Mutation: {
-    createTask(parent, args, context) {
-      return null;
+    createTask: async (
+      parent, 
+      args: { input: { title: string } }, 
+      context
+    ): Promise<Task> => {
+      try {
+        const task = await Task.create({ 
+          title: args.input.title, 
+          status: TaskStatus.active 
+        });
+        return task;
+      } catch (err) {
+        console.error(err);
+      };
     },
     updateTask(parent, args, context) {
       return null;

--- a/apollo/schemas/typeDefs.ts
+++ b/apollo/schemas/typeDefs.ts
@@ -8,7 +8,7 @@ const typeDefs = gql`
   }
 
   type Task {
-    id: Int!
+    id: ID
     title: String!
     status: TaskStatus!
   }
@@ -18,7 +18,7 @@ const typeDefs = gql`
   }
 
   input UpdateTaskInput {
-    id: Int!
+    id: ID
     title: String
     status: TaskStatus
   }
@@ -39,7 +39,7 @@ const typeDefs = gql`
 
   type Query {
     tasks(status: TaskStatus): [Task!]!
-    task(id: Int!): Task
+    task(id: ID!): Task
     books: [Book]
     users: [User]
   }
@@ -47,7 +47,7 @@ const typeDefs = gql`
   type Mutation {
     createTask(input: CreateTaskInput!): Task
     updateTask(input: UpdateTaskInput!): Task
-    deleteTask(id: Int!): Task
+    deleteTask(id: ID!): Task
   }
 `;
 

--- a/src/pages/api/graphql.ts
+++ b/src/pages/api/graphql.ts
@@ -1,6 +1,11 @@
 import { ApolloServer } from '@apollo/server';
 import { startServerAndCreateNextHandler } from '@as-integrations/next';
 import { typeDefs, resolvers } from '../../../apollo/schemas';
+const db = require('./config/connection');
+
+db.once('open', () => {
+  console.log('testing');
+});
 
 const server = new ApolloServer({
   typeDefs,

--- a/src/pages/api/models/Task.ts
+++ b/src/pages/api/models/Task.ts
@@ -1,23 +1,32 @@
-import mongoose, { Schema, Document } from 'mongoose';
+import mongoose, { Schema, Types } from 'mongoose';
 
-interface TaskInterface extends Document {
+enum TaskStatus {
+  active = 'active',
+  completed = 'completed',
+}
+
+interface TaskInterface {
+  id: Types.ObjectId,
   title: string;
-  status: string;
+  status: TaskStatus;
 };
 
 const taskSchema = new Schema<TaskInterface>(
   {
+    id: {
+      type: Schema.Types.ObjectId,
+      required: true
+    },
     title: {
       type: String,
       required: true,
     },
     status: {
       type: String,
-      required: true
+      required: true,
+      enum: Object.values(TaskStatus)
     }
   }
 );
 
-export default 
-  (mongoose.models.Task as mongoose.Model<TaskInterface>) ||
-  mongoose.model<TaskInterface>('Task', taskSchema);
+export default (mongoose.models.Task as mongoose.Model<TaskInterface>) || mongoose.model<TaskInterface>('Task', taskSchema);

--- a/src/pages/api/models/User.ts
+++ b/src/pages/api/models/User.ts
@@ -16,7 +16,4 @@ const userSchema = new Schema<UserInterface>({
   }
 });
 
-export default 
-  (mongoose.models.User as mongoose.Model<UserInterface>) || 
-  mongoose.model<UserInterface>('User', userSchema)
-  
+export default (mongoose.models.User as mongoose.Model<UserInterface>) || mongoose.model<UserInterface>('User', userSchema);


### PR DESCRIPTION
- creating resolvers: task query (with optional filter on task status) & createTask mutation
- changing task related status to status instead of mix of status and task_status
- adding interfaces and enums to better utilize TypeScript benefits