### PR TITLE
adding updateTasks fullstack functionality

### DIFF
--- a/generated/graphql-frontend.ts
+++ b/generated/graphql-frontend.ts
@@ -82,10 +82,24 @@ export type CreateTaskMutationVariables = Exact<{
 
 export type CreateTaskMutation = { __typename?: 'Mutation', createTask?: { __typename?: 'Task', id?: string | null, status: TaskStatus, title: string } | null };
 
+export type UpdateTaskMutationVariables = Exact<{
+  input: UpdateTaskInput;
+}>;
+
+
+export type UpdateTaskMutation = { __typename?: 'Mutation', updateTask?: { __typename?: 'Task', id?: string | null, status: TaskStatus, title: string } | null };
+
 export type TasksQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type TasksQuery = { __typename?: 'Query', tasks: Array<{ __typename?: 'Task', id?: string | null, title: string, status: TaskStatus }> };
+
+export type TaskQueryVariables = Exact<{
+  id: Scalars['ID'];
+}>;
+
+
+export type TaskQuery = { __typename?: 'Query', task?: { __typename?: 'Task', id?: string | null, status: TaskStatus, title: string } | null };
 
 
 export const CreateTaskDocument = gql`
@@ -123,6 +137,41 @@ export function useCreateTaskMutation(baseOptions?: Apollo.MutationHookOptions<C
 export type CreateTaskMutationHookResult = ReturnType<typeof useCreateTaskMutation>;
 export type CreateTaskMutationResult = Apollo.MutationResult<CreateTaskMutation>;
 export type CreateTaskMutationOptions = Apollo.BaseMutationOptions<CreateTaskMutation, CreateTaskMutationVariables>;
+export const UpdateTaskDocument = gql`
+    mutation UpdateTask($input: UpdateTaskInput!) {
+  updateTask(input: $input) {
+    id
+    status
+    title
+  }
+}
+    `;
+export type UpdateTaskMutationFn = Apollo.MutationFunction<UpdateTaskMutation, UpdateTaskMutationVariables>;
+
+/**
+ * __useUpdateTaskMutation__
+ *
+ * To run a mutation, you first call `useUpdateTaskMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateTaskMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateTaskMutation, { data, loading, error }] = useUpdateTaskMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateTaskMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTaskMutation, UpdateTaskMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateTaskMutation, UpdateTaskMutationVariables>(UpdateTaskDocument, options);
+      }
+export type UpdateTaskMutationHookResult = ReturnType<typeof useUpdateTaskMutation>;
+export type UpdateTaskMutationResult = Apollo.MutationResult<UpdateTaskMutation>;
+export type UpdateTaskMutationOptions = Apollo.BaseMutationOptions<UpdateTaskMutation, UpdateTaskMutationVariables>;
 export const TasksDocument = gql`
     query Tasks {
   tasks {
@@ -159,3 +208,40 @@ export function useTasksLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Task
 export type TasksQueryHookResult = ReturnType<typeof useTasksQuery>;
 export type TasksLazyQueryHookResult = ReturnType<typeof useTasksLazyQuery>;
 export type TasksQueryResult = Apollo.QueryResult<TasksQuery, TasksQueryVariables>;
+export const TaskDocument = gql`
+    query Task($id: ID!) {
+  task(id: $id) {
+    id
+    status
+    title
+  }
+}
+    `;
+
+/**
+ * __useTaskQuery__
+ *
+ * To run a query within a React component, call `useTaskQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTaskQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTaskQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useTaskQuery(baseOptions: Apollo.QueryHookOptions<TaskQuery, TaskQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TaskQuery, TaskQueryVariables>(TaskDocument, options);
+      }
+export function useTaskLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TaskQuery, TaskQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TaskQuery, TaskQueryVariables>(TaskDocument, options);
+        }
+export type TaskQueryHookResult = ReturnType<typeof useTaskQuery>;
+export type TaskLazyQueryHookResult = ReturnType<typeof useTaskLazyQuery>;
+export type TaskQueryResult = Apollo.QueryResult<TaskQuery, TaskQueryVariables>;

--- a/src/components/CreateTaskForm.tsx
+++ b/src/components/CreateTaskForm.tsx
@@ -22,7 +22,7 @@ const CreateTaskForm: React.FC<Props> = ({ onSuccess }) => {
       try {
         await createTask({ variables: { input: { title }}});
       } catch (err) {
-        console.error(err);
+        // Log the error.
       };
     };
   };

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Task } from '../../generated/graphql-frontend';
+import Link from 'next/link';
 
 interface Props {
   tasks: Task[];
@@ -10,7 +11,12 @@ const TaskList: React.FC<Props> = ({ tasks }) => {
     <ul className="task-list">
       {tasks.map((task) => (
         <li key={task.id} className="task-list-item">
-          {task.title} ({task.status})
+          <Link href="/update/[id]" as={`/update/${task.id}`}>
+            <div className="task-list-item-title">
+              {task.title} 
+            </div>
+          </Link>
+          ({task.status})
         </li>
       ))}
     </ul>

--- a/src/components/UpdateTaskForm.tsx
+++ b/src/components/UpdateTaskForm.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+import { useUpdateTaskMutation } from '../../generated/graphql-frontend';
+import { isApolloError } from '@apollo/client';
+import { useRouter } from 'next/router';
+
+interface Values {
+  title: string;
+};
+
+interface Props {
+  id: string;
+  initialValues: Values;
+};
+
+const UpdateTaskForm: React.FC<Props> = ({ id, initialValues }) => {
+  const [values, setValues] = useState<Values>(initialValues);
+
+  const onTitleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    const { name, value }  = e.target
+    setValues((prevValues) => ({
+      ...prevValues,
+      [name]: value
+    }));
+  };
+
+  const [updateTask, { loading: updateLoading, error: updateError }] = useUpdateTaskMutation();
+  const router = useRouter();
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+    try {
+      const updatedTask = await updateTask({
+        variables: {
+          input: {
+            id,
+            title: values.title
+          }
+        }
+      }); 
+      if (updatedTask.data?.updateTask) {
+        router.push('/');
+      };
+    } catch (err) {
+
+    };
+  };
+
+  let errorMessage = '';
+  if (updateError) {
+    if (updateError.networkError) {
+      errorMessage = 'A network error occurred, please try again.';
+    } else {
+      errorMessage = 'Sorry, an error occurred.';
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {updateError && <p className="alert-error">Error while updating task: {updateError.message}</p>}
+      <p>
+        <label className="field-label">Title</label>
+        <input 
+          type="text" 
+          name="title" 
+          className="text-input" 
+          value={values.title}
+          onChange={onTitleChange}
+        />
+      </p>
+      <p>
+        <button 
+          type="submit" 
+          className="button" 
+          disabled={updateLoading}
+        >
+          {updateLoading ? 'Loading' : 'Save'}
+        </button>
+      </p>
+    </form>
+  );
+};
+
+export default UpdateTaskForm;

--- a/src/pages/update/[id].tsx
+++ b/src/pages/update/[id].tsx
@@ -1,0 +1,45 @@
+import { GetServerSideProps } from 'next';
+import { initializeApollo } from '../../lib/client';
+import { TaskDocument, TaskQuery, TaskQueryVariables, useTaskQuery } from '../../../generated/graphql-frontend';
+import { useRouter } from 'next/router';
+import Error from 'next/error';
+import UpdateTaskForm from '../../components/UpdateTaskForm';
+
+const UpdateTask = () => {
+  const router = useRouter();
+  
+  const id = typeof router.query?.id === 'string' ? router.query.id : null;
+  if (!id) {
+    return <Error statusCode={404}/>
+  };
+
+  const { loading, data, error } = useTaskQuery({ variables: { id }});
+  const task = data?.task;
+
+  return (
+    <>
+      {loading && <p>Loading...</p>}
+      {error && <p>An error occurred</p>}
+      {task ? 
+        <UpdateTaskForm id={task.id} initialValues={{ title: task.title }} /> :
+        <p>Task not found</p>
+      }
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const id = typeof ctx.params?.id === 'string' ? ctx.params.id : null;
+  if (id) {
+    const apolloClient = initializeApollo();
+    await apolloClient.query<TaskQuery, TaskQueryVariables>({
+      query: TaskDocument,
+      variables: { id }
+    });
+    return { props: {initialApolloState: apolloClient.cache.extract() } };
+  };
+
+  return { props: {} }
+};
+
+export default UpdateTask;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,7 +6,7 @@
     0 4px 6px -2px rgba(0, 0, 0, 0.05);
   --default-space: 2rem;
   --default-radius: 0.25rem;
-  --bg-highlight: #c0c2C9;
+  --bg-highlight: #D3D3D3;
   --text-color: #4a5568;
   --text-light-color: #718096;
 }

--- a/src/utils/graphql/mutations.graphql
+++ b/src/utils/graphql/mutations.graphql
@@ -5,3 +5,11 @@ mutation CreateTask($input: CreateTaskInput!) {
     title
   }
 }
+
+mutation UpdateTask($input: UpdateTaskInput!) {
+  updateTask(input: $input) {
+    id
+    status
+    title
+  }
+}

--- a/src/utils/graphql/queries.graphql
+++ b/src/utils/graphql/queries.graphql
@@ -5,3 +5,11 @@ query Tasks {
     status
   }
 }
+
+query Task($id: ID!) {
+  task(id: $id) {
+    id
+    status
+    title
+  }
+}


### PR DESCRIPTION
- Changed task ids within typeDefs to be a string
- Adding task (singular) query within utils/graphql/queries and updateTask mutation within utils/graphql/mutations. The user updates a task via clicking the task title on the main page, thus both were built within the same branch
- Updating codegen generated files as a result of adding in the new query and mutation
- Creating dynamic [id] page and UpdateTaskForm component
- using getStaticServerProps within [id] page for server side rendering done within Next.js; the [id] page is based on the task id which was changed within typeDefs to be a string as mongoose creates _ids as an Object.id which can be converted to string within resolvers