### PR TITLE
Running delete task mutation frontend

### DIFF
--- a/generated/graphql-frontend.ts
+++ b/generated/graphql-frontend.ts
@@ -89,6 +89,13 @@ export type UpdateTaskMutationVariables = Exact<{
 
 export type UpdateTaskMutation = { __typename?: 'Mutation', updateTask?: { __typename?: 'Task', id?: string | null, status: TaskStatus, title: string } | null };
 
+export type MutationMutationVariables = Exact<{
+  deleteTaskId: Scalars['ID'];
+}>;
+
+
+export type MutationMutation = { __typename?: 'Mutation', deleteTask?: { __typename?: 'Task', id?: string | null, status: TaskStatus, title: string } | null };
+
 export type TasksQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -172,6 +179,41 @@ export function useUpdateTaskMutation(baseOptions?: Apollo.MutationHookOptions<U
 export type UpdateTaskMutationHookResult = ReturnType<typeof useUpdateTaskMutation>;
 export type UpdateTaskMutationResult = Apollo.MutationResult<UpdateTaskMutation>;
 export type UpdateTaskMutationOptions = Apollo.BaseMutationOptions<UpdateTaskMutation, UpdateTaskMutationVariables>;
+export const MutationDocument = gql`
+    mutation Mutation($deleteTaskId: ID!) {
+  deleteTask(id: $deleteTaskId) {
+    id
+    status
+    title
+  }
+}
+    `;
+export type MutationMutationFn = Apollo.MutationFunction<MutationMutation, MutationMutationVariables>;
+
+/**
+ * __useMutationMutation__
+ *
+ * To run a mutation, you first call `useMutationMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useMutationMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [mutationMutation, { data, loading, error }] = useMutationMutation({
+ *   variables: {
+ *      deleteTaskId: // value for 'deleteTaskId'
+ *   },
+ * });
+ */
+export function useMutationMutation(baseOptions?: Apollo.MutationHookOptions<MutationMutation, MutationMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<MutationMutation, MutationMutationVariables>(MutationDocument, options);
+      }
+export type MutationMutationHookResult = ReturnType<typeof useMutationMutation>;
+export type MutationMutationResult = Apollo.MutationResult<MutationMutation>;
+export type MutationMutationOptions = Apollo.BaseMutationOptions<MutationMutation, MutationMutationVariables>;
 export const TasksDocument = gql`
     query Tasks {
   tasks {

--- a/generated/graphql-frontend.ts
+++ b/generated/graphql-frontend.ts
@@ -89,12 +89,12 @@ export type UpdateTaskMutationVariables = Exact<{
 
 export type UpdateTaskMutation = { __typename?: 'Mutation', updateTask?: { __typename?: 'Task', id?: string | null, status: TaskStatus, title: string } | null };
 
-export type MutationMutationVariables = Exact<{
-  deleteTaskId: Scalars['ID'];
+export type DeleteTaskMutationVariables = Exact<{
+  id: Scalars['ID'];
 }>;
 
 
-export type MutationMutation = { __typename?: 'Mutation', deleteTask?: { __typename?: 'Task', id?: string | null, status: TaskStatus, title: string } | null };
+export type DeleteTaskMutation = { __typename?: 'Mutation', deleteTask?: { __typename?: 'Task', id?: string | null, status: TaskStatus, title: string } | null };
 
 export type TasksQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -179,41 +179,41 @@ export function useUpdateTaskMutation(baseOptions?: Apollo.MutationHookOptions<U
 export type UpdateTaskMutationHookResult = ReturnType<typeof useUpdateTaskMutation>;
 export type UpdateTaskMutationResult = Apollo.MutationResult<UpdateTaskMutation>;
 export type UpdateTaskMutationOptions = Apollo.BaseMutationOptions<UpdateTaskMutation, UpdateTaskMutationVariables>;
-export const MutationDocument = gql`
-    mutation Mutation($deleteTaskId: ID!) {
-  deleteTask(id: $deleteTaskId) {
+export const DeleteTaskDocument = gql`
+    mutation DeleteTask($id: ID!) {
+  deleteTask(id: $id) {
     id
     status
     title
   }
 }
     `;
-export type MutationMutationFn = Apollo.MutationFunction<MutationMutation, MutationMutationVariables>;
+export type DeleteTaskMutationFn = Apollo.MutationFunction<DeleteTaskMutation, DeleteTaskMutationVariables>;
 
 /**
- * __useMutationMutation__
+ * __useDeleteTaskMutation__
  *
- * To run a mutation, you first call `useMutationMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useMutationMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useDeleteTaskMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteTaskMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [mutationMutation, { data, loading, error }] = useMutationMutation({
+ * const [deleteTaskMutation, { data, loading, error }] = useDeleteTaskMutation({
  *   variables: {
- *      deleteTaskId: // value for 'deleteTaskId'
+ *      id: // value for 'id'
  *   },
  * });
  */
-export function useMutationMutation(baseOptions?: Apollo.MutationHookOptions<MutationMutation, MutationMutationVariables>) {
+export function useDeleteTaskMutation(baseOptions?: Apollo.MutationHookOptions<DeleteTaskMutation, DeleteTaskMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<MutationMutation, MutationMutationVariables>(MutationDocument, options);
+        return Apollo.useMutation<DeleteTaskMutation, DeleteTaskMutationVariables>(DeleteTaskDocument, options);
       }
-export type MutationMutationHookResult = ReturnType<typeof useMutationMutation>;
-export type MutationMutationResult = Apollo.MutationResult<MutationMutation>;
-export type MutationMutationOptions = Apollo.BaseMutationOptions<MutationMutation, MutationMutationVariables>;
+export type DeleteTaskMutationHookResult = ReturnType<typeof useDeleteTaskMutation>;
+export type DeleteTaskMutationResult = Apollo.MutationResult<DeleteTaskMutation>;
+export type DeleteTaskMutationOptions = Apollo.BaseMutationOptions<DeleteTaskMutation, DeleteTaskMutationVariables>;
 export const TasksDocument = gql`
     query Tasks {
   tasks {

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Task } from '../../generated/graphql-frontend';
 import Link from 'next/link';
+import TaskListItem from './TaskListItem';
 
 interface Props {
   tasks: Task[];
@@ -10,14 +11,7 @@ const TaskList: React.FC<Props> = ({ tasks }) => {
   return (
     <ul className="task-list">
       {tasks.map((task) => (
-        <li key={task.id} className="task-list-item">
-          <Link href="/update/[id]" as={`/update/${task.id}`}>
-            <div className="task-list-item-title">
-              {task.title} 
-            </div>
-          </Link>
-          ({task.status})
-        </li>
+        <TaskListItem key={task.id} task={task} />
       ))}
     </ul>
   );

--- a/src/components/TaskListItem.tsx
+++ b/src/components/TaskListItem.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Task } from '../../generated/graphql-frontend';
+import Link from 'next/link';
+
+interface Props {
+  task: Task;
+}
+
+const TaskListItem: React.FC<Props> = ({ task }) => {
+  return (
+    <li key={task.id} className="task-list-item">
+      <Link href="/update/[id]" as={`/update/${task.id}`}>
+        <div className="task-list-item-title">
+          {task.title} 
+        </div>
+      </Link>
+      ({task.status})
+    </li>
+  );
+}
+
+export default TaskListItem;

--- a/src/components/TaskListItem.tsx
+++ b/src/components/TaskListItem.tsx
@@ -1,12 +1,46 @@
-import React from 'react';
-import { Task } from '../../generated/graphql-frontend';
+import React, { useEffect } from 'react';
+import { Task, useDeleteTaskMutation } from '../../generated/graphql-frontend';
 import Link from 'next/link';
+import { Reference } from '@apollo/client';
 
 interface Props {
   task: Task;
 }
 
 const TaskListItem: React.FC<Props> = ({ task }) => {
+  const [deleteTask, { loading: deleteLoading, error: deleteError }] = useDeleteTaskMutation({
+    variables: { id: task.id },
+    errorPolicy: 'all',
+    update: (cache, result) => {
+      const deletedTask = result.data?.deleteTask
+      if (deletedTask) {
+        cache.modify({
+          fields: {
+            tasks: (taskRefs: Reference[], { readField }) => {
+              return taskRefs.filter(taskRef => {
+                return readField('id', taskRef) !== deletedTask.id;
+              })
+            }
+          }
+        });
+      }
+    }
+  });
+  const handleDeleteClick: React.MouseEventHandler<HTMLButtonElement> = async () => {
+    try {
+     await deleteTask();
+    } catch (err) {
+      // Log the error
+      console.log(err);
+    };
+  };
+
+  useEffect(() => {
+    if (deleteError) {
+      alert('An error occurred, please try again.');
+    }
+  }, [deleteError]);
+
   return (
     <li key={task.id} className="task-list-item">
       <Link href="/update/[id]" as={`/update/${task.id}`}>
@@ -15,8 +49,15 @@ const TaskListItem: React.FC<Props> = ({ task }) => {
         </div>
       </Link>
       ({task.status})
+      <button 
+        className="task-list-item-delete" 
+        onClick={handleDeleteClick}
+        disabled={deleteLoading}
+      >
+        &times;
+      </button>
     </li>
   );
-}
+};
 
 export default TaskListItem;

--- a/src/utils/graphql/mutations.graphql
+++ b/src/utils/graphql/mutations.graphql
@@ -13,3 +13,11 @@ mutation UpdateTask($input: UpdateTaskInput!) {
     title
   }
 }
+
+mutation Mutation($deleteTaskId: ID!) {
+  deleteTask(id: $deleteTaskId) {
+    id
+    status
+    title
+  }
+}

--- a/src/utils/graphql/mutations.graphql
+++ b/src/utils/graphql/mutations.graphql
@@ -14,8 +14,8 @@ mutation UpdateTask($input: UpdateTaskInput!) {
   }
 }
 
-mutation Mutation($deleteTaskId: ID!) {
-  deleteTask(id: $deleteTaskId) {
+mutation DeleteTask($id: ID!) {
+  deleteTask(id: $id) {
     id
     status
     title


### PR DESCRIPTION
NOTE: accidentally forgot to encapsulate all that hapens in the most recent commit prior to this pull request

- added in deleteTask mutation within utils/graphql
- regenerated codegen for frontend
- created TaskListItem component and removed logic from TaskList, TaskListItem will account for deletions
- using update from useDeleteTaskMutation to edit cache in apollo client