### PR TITLE
using single page to render tasks list

### DIFF
--- a/src/components/TaskFilter.tsx
+++ b/src/components/TaskFilter.tsx
@@ -10,7 +10,7 @@ const TaskFilter: React.FC<Props> = ({ status }) => {
   return (
     <ul className="task-filter">
       <li>
-        <Link href="/" scroll={false}>
+        <Link href="/" scroll={false} shallow={true}>
           <div className={!status ? 'task-filter-active' : ''}>
             All
           </div>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const Custom404 = () => {
+  return (
+    <h1>404- Page not found</h1>
+  );
+};
+
+export default Custom404

--- a/src/pages/[[...status]].tsx
+++ b/src/pages/[[...status]].tsx
@@ -5,9 +5,9 @@ import { TaskStatus, TasksDocument, TasksQuery, TasksQueryVariables, useTasksQue
 import TaskList from '../components/TaskList.tsx';
 import CreateTaskForm from '../components/CreateTaskForm.tsx';
 import { useRouter } from 'next/router';
-import Error from 'next/error';
 import TaskFilter from '../components/TaskFilter.tsx';
 import { useEffect, useRef } from 'react';
+import Custom404 from './404.tsx';
 
 const isTaskStatus = (value: string): value is TaskStatus =>
   Object.values(TaskStatus).includes(value as TaskStatus);
@@ -25,9 +25,9 @@ const convertQueryStatusToEnum = (status) => {
 
 const Home = () => {
   const router = useRouter();
-  const status = typeof router.query.status === 'string' ? router.query.status : undefined;
+  const status = Array.isArray(router.query.status) ? router.query.status[0] : undefined;
   if (status !== undefined && !isTaskStatus(status)) {
-    return <Error statusCode={404} />;
+    return <Custom404 />;
   };
 
   const prevStatus = useRef(status);
@@ -65,8 +65,8 @@ const Home = () => {
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const status =
-  typeof ctx.params?.status === 'string'
-    ? ctx.params.status
+  Array.isArray(ctx.params.status) 
+    ? ctx.params.status[0]
     : undefined;
 
   if (status === undefined || isTaskStatus(status)) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,1 +1,0 @@
-export { default, getServerSideProps } from './[status]';

--- a/src/pages/update/[id].tsx
+++ b/src/pages/update/[id].tsx
@@ -2,15 +2,15 @@ import { GetServerSideProps } from 'next';
 import { initializeApollo } from '../../lib/client';
 import { TaskDocument, TaskQuery, TaskQueryVariables, useTaskQuery } from '../../../generated/graphql-frontend';
 import { useRouter } from 'next/router';
-import Error from 'next/error';
 import UpdateTaskForm from '../../components/UpdateTaskForm';
+import Custom404 from '../404';
 
 const UpdateTask = () => {
   const router = useRouter();
   
   const id = typeof router.query?.id === 'string' ? router.query.id : null;
   if (!id) {
-    return <Error statusCode={404}/>
+    return <Custom404 />;
   };
 
   const { loading, data, error } = useTaskQuery({ variables: { id }});


### PR DESCRIPTION
- using next.js dynamic routes with optional catch all routes to consolidate index.tsx and [status] page which requires new naming as [[...status]] [https://nextjs.org/docs/routing/dynamic-routes](https://nextjs.org/docs/routing/dynamic-routes) Refer to optional catch all routes
- adding in a custom barebones 404 page
- updating TaskFilter to now include shallow as true within index route