### PR TITLE
more styling to accomodate smaller screens

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -53,7 +53,7 @@ button {
   margin: 0 auto;
   max-width: 600px;
   padding: 0 1rem;
-  min-height: 100vh;
+  min-height: 90vh;
 }
 
 .logo {
@@ -206,9 +206,8 @@ button {
 
 .copyrightText {
   display: flex; 
-  justify-content: flex-end;
+  justify-content: center;
   align-items: center;
-  margin-right: 50px;
 }
 
 .techstackContainer {
@@ -216,8 +215,7 @@ button {
   flex-wrap: wrap;
   align-items: center;
   width:100%;
-  justify-content: flex-start;
-  margin-left: 50px;
+  justify-content: center;
 }
 
 .links-container {
@@ -225,16 +223,11 @@ button {
   cursor: pointer;
 }
 
-@media (max-width:500px) {
+@media (max-width:700px) {
   .footerContainer {
     display: flex;
     flex-direction: column;
     margin-top: 10px;
     margin-bottom: 20px;
-  }
-
-  .copyrightText {
-    justify-content: center;
-    margin-right: 0;
   }
 }


### PR DESCRIPTION
- removing justify-content flex-start for techStackcontainer, replacing with center
- removing justify-content flex-end for copyrightText, replacing with center
- changing min-height on page so footer isn't just out of sight